### PR TITLE
Get_Result() returns bool on error which is not caught

### DIFF
--- a/src/Ql/MySQLiConnection.php
+++ b/src/Ql/MySQLiConnection.php
@@ -170,14 +170,14 @@ class MySQLiConnection extends AbstractQlConnection
   protected function _fetchQueryResults($query, array $values = null)
   {
     $stmt = $this->_executeQuery($query, $values);
-    $rows = $stmt->get_result();
-    if($rows === false) //get_result() returns false on error
+    $result = $stmt->get_result();
+    if($result === false) //get_result() returns false on error
     {
       throw new ConnectionException(
         $this->_connection->error, $this->_connection->errno
       );
     }
-    $rows->fetch_all(MYSQLI_ASSOC);
+    $rows = $result->fetch_all(MYSQLI_ASSOC);
     $stmt->free_result();
     return $rows;
   }

--- a/src/Ql/MySQLiConnection.php
+++ b/src/Ql/MySQLiConnection.php
@@ -3,6 +3,7 @@ namespace Packaged\Dal\Ql;
 
 use Packaged\Dal\Exceptions\Connection\ConnectionException;
 use Packaged\Dal\Exceptions\Connection\DuplicateKeyException;
+use Packaged\Dal\Exceptions\Connection\PdoException;
 use Packaged\Helpers\ValueAs;
 
 class MySQLiConnection extends AbstractQlConnection
@@ -170,7 +171,14 @@ class MySQLiConnection extends AbstractQlConnection
   protected function _fetchQueryResults($query, array $values = null)
   {
     $stmt = $this->_executeQuery($query, $values);
-    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $rows = $stmt->get_result();
+    if($rows === false) //get_result() returns false on error
+    {
+      throw new PDOException(
+        $this->_connection->error, $this->_connection->errno
+      );
+    }
+    $rows->fetch_all(MYSQLI_ASSOC);
     $stmt->free_result();
     return $rows;
   }

--- a/src/Ql/MySQLiConnection.php
+++ b/src/Ql/MySQLiConnection.php
@@ -3,7 +3,6 @@ namespace Packaged\Dal\Ql;
 
 use Packaged\Dal\Exceptions\Connection\ConnectionException;
 use Packaged\Dal\Exceptions\Connection\DuplicateKeyException;
-use Packaged\Dal\Exceptions\Connection\PdoException;
 use Packaged\Helpers\ValueAs;
 
 class MySQLiConnection extends AbstractQlConnection
@@ -174,7 +173,7 @@ class MySQLiConnection extends AbstractQlConnection
     $rows = $stmt->get_result();
     if($rows === false) //get_result() returns false on error
     {
-      throw new PDOException(
+      throw new ConnectionException(
         $this->_connection->error, $this->_connection->errno
       );
     }


### PR DESCRIPTION
get_result() returns a bool when it errors. This is causing "Call to a member function fetch_all()" when fetch_all is called from the bool result. We now throw a PDO exception with the error string and number from the last connection error.