### PR TITLE
The docblock above \Packaged\Dal\Ql\QlDao::loadOneWhere is incorrect …

### DIFF
--- a/src/Ql/QlDao.php
+++ b/src/Ql/QlDao.php
@@ -114,7 +114,7 @@ abstract class QlDao extends AbstractSanitizableDao
   /**
    * @param $params
    *
-   * @return static
+   * @return static|null
    *
    * @throws MultipleDaoException
    */

--- a/src/Ql/QlDaoCollection.php
+++ b/src/Ql/QlDaoCollection.php
@@ -203,7 +203,7 @@ class QlDaoCollection extends DaoCollection
    *
    * @param mixed $default
    *
-   * @return QlDao
+   * @return QlDao|null|mixed
    */
   public function first($default = null)
   {


### PR DESCRIPTION
The docblock above \Packaged\Dal\Ql\QlDao::loadOneWhere is incorrect as it says that it will always return static which is not true as the default value of \Packaged\Dal\Ql\QlDaoCollection::first is null

By the same token the return value of \Packaged\Dal\Ql\QlDaoCollection::first should be QlDao|null|mixed as the default value if passed can be set to anything